### PR TITLE
Sta Laravel 13 toe (v5)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^7",
-        "illuminate/support": "^6|^7|^8|^9|^10.0|^11.0|^12.0",
-        "illuminate/http": "^6|^7|^8|^9|^10.0|^11.0|^12.0",
+        "illuminate/support": "^6|^7|^8|^9|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^6|^7|^8|^9|^10.0|^11.0|^12.0|^13.0",
         "unleash/client": "^1",
         "symfony/cache": "^5.3|^6.1",
         "psr/cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
## Wat
Verbreedt de framework-constraints op de `release/v5.x.x`-branch zodat unleash ook Laravel 13 toestaat:

- `illuminate/support`: `…|^12.0` → `…|^12.0|^13.0`
- `illuminate/http`: `…|^12.0` → `…|^12.0|^13.0`

## Waarom
Vervolg op de Laravel 11→12 upgrade van WHOON (WHOON-4604). Zodat unleash mee kan naar Laravel 13.

## Let op
- Laravel 13 is nog **niet uitgebracht**; dit is uitsluitend een constraint-verbreding. Code-compatibiliteit valt pas te verifiëren zodra L13 beschikbaar is.
- **`symfony/cache: ^5.3|^6.1`** ondersteunt geen Symfony 8 (verwacht bij Laravel 13). Op L12 lost dit nu al naar symfony/cache 6.4 op náást Laravel's Symfony 7; bij L13 zal deze constraint waarschijnlijk óók verbreed moeten worden (bijv. `^5.3|^6.1|^7.0|^8.0`), anders blijft unleash op L13 oninstalleerbaar. Niet meegenomen in deze PR omdat de exacte Symfony-versie van L13 nog onbekend is.