### PR TITLE
Sta unleash/client v2 toe (Laravel 13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^7",
         "illuminate/support": "^6|^7|^8|^9|^10.0|^11.0|^12.0|^13.0",
         "illuminate/http": "^6|^7|^8|^9|^10.0|^11.0|^12.0|^13.0",
-        "unleash/client": "^1",
+        "unleash/client": "^1 || ^2",
         "symfony/cache": "^5.3|^6.1",
         "psr/cache": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
## Wat
- `unleash/client`: `^1` → `^1 || ^2`

## Waarom
Voor de Laravel 13-upgrade van WHOON (WHOON-4604). De L13-stack (o.a. laravel/passport v13, guzzle) vereist `psr/http-message ^2.0`, maar alle `unleash/client` v1.x pinnen `psr/http-message ^1.0` → conflict. `unleash/client v2.9.x` staat `psr/http-message ^1.0 || ^2.0` toe, dus die major moet toegestaan worden.

## ⚠️ Code-compat verifiëren vóór tag
Dit is een **major bump van de upstream SDK (v1 → v2)**. Deze wrapper gebruikt o.a. `Unleash\Client\Configuration\…` en de `Unleash`-interface (zie `src/Unleash.php`, `src/Facades/Unleash.php`, `src/Providers/UnleashContextProvider.php`). Controleer dat die API in unleash/client v2 ongewijzigd is (of pas de wrapper aan) en draai de unit tests vóór het taggen van een nieuwe v5.x.